### PR TITLE
Fix pip install jupyter warning

### DIFF
--- a/ex_06_model_composition.ipynb
+++ b/ex_06_model_composition.ipynb
@@ -66,7 +66,7 @@
     }
    ],
    "source": [
-    "!pip install transformers torch"
+    "%pip install transformers torch"
    ]
   },
   {


### PR DESCRIPTION
vscode was complaning, see https://github.com/microsoft/vscode-jupyter/wiki/Installing-Python-packages-in-Jupyter-Notebooks